### PR TITLE
Remove deprecated `memchr` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ quickcheck = { version = "0.8", default-features = false }
 [features]
 # stable and pcmp support: opting out of using std, becoming no_std
 default = ["use_std"]
-use_std = ["memchr/use_std"]
+use_std = ["memchr/std"]
 
 # Internal features for testing & benchmarking & development
 pattern = []


### PR DESCRIPTION
The `use_std` feature is deprecated in favor of `std`: https://github.com/BurntSushi/rust-memchr/commit/8efd67fcc412445d6978cf35761ab81ed2d6e6fe#diff-80398c5faae3c069e4e6aa2ed11b28c0